### PR TITLE
Fix Quick Start clone command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ export default function Page() {
 ## Quick Start
 
 ```bash
-git clone fluid-design-io/payload-better-auth-starter
+git clone https://github.com/fluid-design-io/payload-better-auth-starter.git
 cd payload-better-auth-starter
 bun install
 cp .env.example .env   # edit with your values


### PR DESCRIPTION
Fixes the clone command in the Quick Start section of the README so the setup flow is clearer and easier to copy/paste.