### PR TITLE
fix: minio redirected causing createbuckets failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     command: >
       sh -c "
         apk add --no-cache curl &&
-        curl -o /tmp/mc https://dl.min.io/client/mc/release/linux-amd64/mc &&
+        curl -L -o /tmp/mc https://dl.min.io/client/mc/release/linux-amd64/mc &&
         chmod +x /tmp/mc &&
         /tmp/mc alias set minio http://minio:9000 ${S3_ACCESS_KEY_ID} ${S3_SECRET_ACCESS_KEY} &&
         /tmp/mc mb minio/${S3_BUCKET} || true &&


### PR DESCRIPTION
dl.min.io now returns 302 to GitHub with a small HTML body. curl without -L saved that as /tmp/mc, so bucket creation failed.

Add curl -fL (follow redirects, fail on HTTP errors) when downloading mc in docker-compose.dev.yml so the real binary is fetched and createbuckets succeeds again.